### PR TITLE
Allow variables to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,14 @@ $fa-font-path = 'fonts'
 @import 'fa-stylus'
 
 ```
+`$fa-font-path` is set to `../fonts` by default.
 
+## Other configuration
+
+The variables used by fa-stylus are set by the library only if not already set.
+That means to override them you must set them before importing fa-stylus.
+
+See [`variables.styl`](fa-stylus/icons/variables.styl) for full details.
 
 ## Usage
 

--- a/fa-stylus/icons/variables.styl
+++ b/fa-stylus/icons/variables.styl
@@ -1,15 +1,15 @@
 // Variables
 // --------------------------
 
-//$fa-font-path = "../fonts"
-//$fa-font-path = "//netdna.bootstrapcdn.com/font-awesome/4.5.0/fonts" // for referencing Bootstrap CDN font files directly
-$fa-font-size-base = 14px
-$fa-line-height-base = 1
-$fa-css-prefix = fa
-$fa-version = "4.5.0"
-$fa-border-color = #eee
-$fa-inverse = #fff
-$fa-li-width = (30em / 14)
+$fa-font-path ?= "../fonts"
+//$fa-font-path ?= "//netdna.bootstrapcdn.com/font-awesome/4.5.0/fonts" // for referencing Bootstrap CDN font files directly
+$fa-font-size-base ?= 14px
+$fa-line-height-base ?= 1
+$fa-css-prefix ?= fa
+$fa-version ?= "4.5.0"
+$fa-border-color ?= #eee
+$fa-inverse ?= #fff
+$fa-li-width ?= (30em / 14)
 
 $fa-icons = {
   icon500px: "\f26e",


### PR DESCRIPTION
Only set the variables if they're not already defined.

This means a user can override any of them before including fa-stylus.
